### PR TITLE
fix: correct Verus (VRSC) compatibility issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
-## Solomining for Komodo ecosystem.
-## (NOT READY FOR TESTING!!!!!!!!!!!!!!)
+## Solomining for Verus (VRSC)
+Fork of [TheComputerGenie/komodo-solomining](https://github.com/TheComputerGenie/komodo-solomining)
+(itself forked from [aayanl/equihash-solomining](https://github.com/aayanl/equihash-solomining)),
+adapted and validated for Verus (VRSC) specifically. See "Verus (VRSC) notes" below for what
+changed and why. Upstream's own coins (KMD, PIRATE, TOKEL, VPRM) are untouched and unvalidated
+here — this fork's focus is VRSC.
 ![](./Screenshot.png)
 ## The solo miner's solo pool
 The objective is a "light-weight" pool that does what needs to be done.  
@@ -31,14 +35,14 @@ sudo apt-get install nodejs -y
 
 sudo npm install npm -g
 
-git clone https://github.com/TheComputerGenie/komodo-solomining
-cd komodo-solomining
+git clone https://github.com/hyclak/verus-solomining
+cd verus-solomining
 npm install
 ```
 
 Configure
 -------------
-Go to config.json and change it to your setup.
+Go to config.json (or VRSC_config.json — see "Run" below) and change it to your setup.
 
 Recomended diffs:
 -------------
@@ -50,8 +54,12 @@ Rentals: 1350000
 Run
 ------------
 ```bash
-npm start
+node init.js          # uses config.json
+node init.js VRSC     # uses VRSC_config.json instead
 ```
+(`npm start`/`npm run startinstall` still work too, but only for the no-arg `config.json` case —
+their `"$1"`-based arg passing can't actually reach `init.js` with a coin argument no matter how
+you invoke npm; see "Verus (VRSC) notes" below.)
 
 Update (normally)
 -------------
@@ -66,6 +74,36 @@ git pull
 rm -rf node_modules
 npm install
 ```
+
+Verus (VRSC) notes
+------------
+Fixes made in this fork to get VRSC working, for anyone adapting this to another coin:
+
+* **`coins/VRSC.json` `peerMagic`**: don't take this from `pchMessageStart` in the daemon's
+  `chainparams.cpp` source — Verus computes its actual runtime P2P magic dynamically
+  (`ASSETCHAINS_MAGIC`, derived from the chain's name and total supply), and it doesn't match
+  the static value in source. Get the real value from the daemon's own startup log
+  (`>>>>>>>>>> VRSC: p2p.27485 rpc.27486 magic.XXXXXXXX ...`) and byte-reverse it — e.g.
+  `magic.e2588aad` becomes `peerMagic: "ad8a58e2"`. It's a fixed property of the chain (derived
+  from immutable name/supply), so it won't change across restarts or software upgrades.
+* **`lib/stratum/transactions.js` `createGeneration`**: reads `vouts[i].valueZat` from the
+  vout array (itself pulled from a `decoderawtransaction` call on the daemon's proposed
+  coinbase, see `pool.js`'s `getRawTransaction`), but VRSC's `decoderawtransaction` returns
+  `valueSat`, not `valueZat`. The missing field silently produced `NaN`, which threw a
+  misleading "value has a fractional component" error deep in `bitgo-utxo-lib` (`NaN !== NaN`
+  in JS satisfies that check same as a real fraction would). Changed to `valueSat`.
+* **`init.js` coin-config selection**: read the CLI arg from `process.argv[3]`, but running
+  `node init.js VRSC` (or via the `npm start`/`startinstall` scripts, which land a single arg
+  at the same position) puts it at `process.argv[2]`. `argv[3]` was never populated, so
+  `VRSC_config.json` (or any `<SYMBOL>_config.json`) could never actually be selected — it
+  silently always fell back to the default `config.json`. Changed to `argv[2]`.
+* **Known unresolved risk**: VRSC coinbase transactions include a `"cryptocondition"`-type
+  vout (its reserve-currency/feepool mechanism) alongside the miner payout. `createGeneration`'s
+  `switch` on `scriptPubKey.type` has no case for `"cryptocondition"` and falls through to the
+  `default` case, which rebuilds it as a plain P2PKH output rather than the
+  `OP_CHECKCRYPTOCONDITION` script consensus likely requires there. Its value has been `0` in
+  testing so far, so this hasn't surfaced as a rejected block/share yet — but if `submitblock`
+  starts failing, this is the first place to look.
 
 Differences between this and Z-NOMP
 ------------

--- a/coins/VRSC.json
+++ b/coins/VRSC.json
@@ -1,0 +1,6 @@
+{
+    "name": "Verus",
+    "symbol": "VRSC",
+    "peerMagic": "ad8a58e2",
+    "txfee": 0.0001
+}

--- a/init.js
+++ b/init.js
@@ -7,7 +7,7 @@ const logging = require('./lib/modules/logging.js');
 const PoolWorker = require('./lib/workers/poolWorker.js');
 const CliListener = require('./lib/workers/cliListener.js');
 
-var config = (process.argv[3] ? require(`./${process.argv[3]}_config.json`) : require('./config.json'));
+var config = (process.argv[2] ? require(`./${process.argv[2]}_config.json`) : require('./config.json'));
 var coinFilePath = `coins/${config.coin}`;
 
 if (!fs.existsSync(coinFilePath))

--- a/lib/stratum/transactions.js
+++ b/lib/stratum/transactions.js
@@ -61,7 +61,7 @@ exports.createGeneration = function(blockHeight, blockReward, poolAddress, coin,
            );
 
     for (var i = 0; i <= vouts.length - 1; i++) {
-        let amt = parseInt(vouts[i].valueZat, 10);
+        let amt = parseInt(vouts[i].valueSat, 10);
         switch (vouts[i].scriptPubKey.type) {
             case "pubkey":
                 txb.addOutput(scriptCompileP2PK(i == 0 ? pubkey : vouts[i].scriptPubKey.asm.split(" ", 1)), amt);


### PR DESCRIPTION
- init.js read the coin-select CLI arg from argv[3], but node's argv only ever puts it at argv[2] regardless of how the npm start scripts invoke it, so <SYMBOL>_config.json could never be selected.
- transactions.js read valueZat off decoderawtransaction's vout array, but Verus (and apparently not all Komodo-family daemons) returns valueSat there, so every amount came through as NaN.
- Added coins/VRSC.json. peerMagic is byte-reversed from the daemon's own startup log ("magic.e2588aad" -> "ad8a58e2"), not the static pchMessageStart in chainparams.cpp, which VRSC's runtime magic computation overrides.
- Updated README to document these fixes and the fork's VRSC focus.